### PR TITLE
Do not require bootstrap node to start signal.

### DIFF
--- a/bin/signal.js
+++ b/bin/signal.js
@@ -59,7 +59,7 @@ yargs
     createBroker(topic, {
       port: argv.port,
       hyperswarm: {
-        bootstrap: argv.bootstrap.split(',')
+        bootstrap: (argv.bootstrap) ? argv.bootstrap.split(',') : undefined
       },
       asBootstrap: argv.asBootstrap,
       repl: argv.repl,


### PR DESCRIPTION
This conditional may need to be changed from undefined to a sane default or --asBootstrap should populate argv.bootstrap